### PR TITLE
Removed require("sys") which is not used, and raises a warning in newer ...

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var sys = require("sys");
 
 var localRoutes = [];
 


### PR DESCRIPTION
...versions of node
