### PR TITLE
Fix for failing RegExp test due to different types

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -164,7 +164,7 @@ for(caseIdx in cases){
     fixture = test.testMatch[path];
     
     //save typing in fixtures
-    fixture.route = test.path;
+    fixture.route = test.path.toString(); // match gets string, so ensure same type
     deepEqual(match, fixture);
     assertCount++;
   }


### PR DESCRIPTION
When running the tests `make test` the following output was generated:

```
node test/test.js

node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
AssertionError: {"params":{},"splats":["123-22-1234","json"],"route":"/^\\/(\\d{2,3}-\\d{2,3}-\\d{4})\\.(\\w*)$/","fn":"function (){}"} deepEqual {"fn":"function (){}","params":{},"splats":["123-22-1234","json"],"route":"/^\\/(\\d{2,3}-\\d{2,3}-\\d{4})\\.(\\w*)$/"}
    at Object.<anonymous> (/Users/barczewskij/projects/routes.js/test/test.js:168:5)
    at Module._compile (module.js:441:26)
    at Object..js (module.js:459:10)
    at Module.load (module.js:348:31)
    at Function._load (module.js:308:12)
    at Array.0 (module.js:479:10)
    at EventEmitter._tickCallback (node.js:192:40)
make: *** [test] Error 1

```

which turned out to be simply that the type of the match and the fixture were different. 

Since the match returns a string and the RegExp fixture has a RegExp the deepEqual assert fails.

The fix simply ensures they both are strings using toString().
