### PR TITLE
replace decodeURIComponent with unescape to avoid malformed URI error

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ var match = function (routes, uri) {
 			for (var j = 1, len = captures.length; j < len; ++j) {
 				var key = keys[j-1],
 					val = typeof captures[j] === 'string'
-						? decodeURIComponent(captures[j])
+						? unescape(captures[j])
 						: captures[j];
 				if (key) {
 					params[key] = val;

--- a/test/test.js
+++ b/test/test.js
@@ -146,6 +146,16 @@ var cases = [
     },
     testNoMatch: ["/123-1-1234.png", "/123-22-1234", "/123.png"]
   },
+  {
+    path: "/cat/*",
+    testMatch: {
+      "/cat/%" :{
+        fn: noop,
+        params: {},
+        splats: ['%']
+      }
+    }
+  }  
 ]
 
 //load routes


### PR DESCRIPTION
https://github.com/aaronblohowiak/routes.js/issues/15
