### PR TITLE
use String.match instead of RegExp.exec to capture uri fragments

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ var pathToRegExp = function (path, keys) {
 				keys.push(undefined);
 				return _;
 			}
-			
+
 			keys.push(key);
 			slash = slash || '';
 			return ''
@@ -88,7 +88,7 @@ var match = function (routes, uri, startAt) {
 		    splats = [],
 		    params = {};
 
-		if (captures = re.exec(uri)) {
+		if (captures = uri.match(re)) {
 			for (var j = 1, len = captures.length; j < len; ++j) {
 				var key = keys[j-1],
 					val = typeof captures[j] === 'string'


### PR DESCRIPTION
This way it's possible to use global search in the given regexp
