### PR TITLE
Fix for #27 + tests

### DIFF
--- a/dist/routes.js
+++ b/dist/routes.js
@@ -62,7 +62,9 @@ var pathToRegExp = function (path, keys) {
 				+ (optional ? '' : slash)
 				+ '(?:'
 				+ (optional ? slash : '')
-				+ (format || '') + (capture || '([^/]+?)') + ')'
+				+ (format || '')
+				+ (capture ? capture.replace(/\*/g, '{0,}').replace(/\./g, '[\\s\\S]') : '([^/]+?)')
+				+ ')'
 				+ (optional || '');
 		})
 		.replace(/([\/.])/g, '\\$1')

--- a/index.js
+++ b/index.js
@@ -61,7 +61,9 @@ var pathToRegExp = function (path, keys) {
 				+ (optional ? '' : slash)
 				+ '(?:'
 				+ (optional ? slash : '')
-				+ (format || '') + (capture || '([^/]+?)') + ')'
+				+ (format || '')
+				+ (capture ? capture.replace(/\*/g, '{0,}').replace(/\./g, '[\\s\\S]') : '([^/]+?)')
+				+ ')'
 				+ (optional || '');
 		})
 		.replace(/([\/.])/g, '\\$1')

--- a/test/test.js
+++ b/test/test.js
@@ -192,6 +192,39 @@ var cases = [
         splats: ["http","","best"]
       }
     }
+  },
+  {
+    path: "/:id([1-9]\\d*)d",
+    testMatch: {
+      "/1d": {
+        fn: noop,
+        params: {
+          id: "1"
+        },
+        splats: []
+      },
+      "/123d": {
+        fn: noop,
+        params: {
+          id: "123"
+        },
+        splats: []
+      }
+    },
+    testNoMatch: ["/0d", "/0123d", "/d1d", "/123asd"]
+  },
+  {
+    path: "/a:test(a.*z)z",
+    testMatch: {
+      "/aabcdzz": {
+        fn: noop,
+        params: {
+          test: "abcdz"
+        },
+        splats: []
+      }
+    },
+    testNoMatch: ["/abcdz", "/aaaz", "/azzz", "/az"]
   }
 ];
 
@@ -212,7 +245,7 @@ for(caseIdx in cases){
 
     //save typing in fixtures
     fixture.route = test.path.toString(); // match gets string, so ensure same type
-    delete match.next; // next shouldn't be compared
+    if (match) delete match.next; // next shouldn't be compared
     deepEqual(match, fixture);
     assertCount++;
   }


### PR DESCRIPTION
Added support for `*` and `.` in named regexps.

Fixed deleting `.next` property from possibly undefined value in
test.js. Resulted error should be AssertionError, not TypeError.
