### PR TITLE
alias addRoute to add

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,6 +134,9 @@ var Router = function(){
       this.routes.push(route);
       this.routeMap[path] = fn;
     },
+    add: function(path, fn){
+      this.addRoute(path, fn);
+    },
 
     match: function(pathname, startAt){
       var route = match(this.routes, pathname, startAt);


### PR DESCRIPTION
Loving this module!

This is a bike shed but I always end up typing `router.addRoute` a lot which seems a bit redundant to me so I've aliased `add` to `addRoute`.
