### PR TITLE
Add license property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://github.com/aaronblohowiak/routes.js",
   "repository": "https://github.com/aaronblohowiak/routes.js.git",
   "author": "Aaron Blohowiak <aaron.blohowiak@gmail.com> (http://github.com/aaronblohowiak)",
+  "license": "MIT",
   "main": "dist/routes",
   "directories": {
     "lib": "."


### PR DESCRIPTION
Thanks so much for routes! I use it quite a bit.

This tiny pull request adds a "license" metadata property to `package.json` so folks can use tools to confirm the license, rather than dig through the package somewhere in `node_modules` when the time comes.
