### PR TITLE
Support for removing routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,6 @@ var Router = function(){
 
       var route = Route(path);
       route.fn = fn;
-      route.idx = this.routes.length;
 
       this.routes.push(route);
       this.routeMap[path] = fn;
@@ -146,26 +145,18 @@ var Router = function(){
         throw new Error('path does not exist: ' + path);
       }
 
-      // find route for this specific path, not necessarily the first that
-      // matches the pattern
       var match;
-      this.routes.forEach(function eachRoute(route) {
-        if (route.src === path) {
-          match = route;
-        }
-      });
+      var newRoutes = [];
 
-      if (match) {
-        this.routes.splice(match.idx, 1);
-        delete this.routeMap[path];
-
-        // re-index
-        for (var i = match.idx; i<this.routes.length; i++) {
-          this.routes[i].idx = i;
+      // copy the routes excluding the route being removed
+      for (var i = 0; i < this.routes.length; i++) {
+        var route = this.routes[i];
+        if (route.src !== path) {
+          newRoutes.push(route);
         }
-        return match;
       }
-      throw new Error('could not remove route for path: ' + path);
+      this.routes = newRoutes;
+      delete this.routeMap[path];
     },
 
     match: function(pathname, startAt){

--- a/index.js
+++ b/index.js
@@ -134,9 +134,38 @@ var Router = function(){
 
       var route = Route(path);
       route.fn = fn;
+      route.idx = this.routes.length;
 
       this.routes.push(route);
       this.routeMap[path] = fn;
+    },
+
+    removeRoute: function(path) {
+      if (!path) throw new Error(' route requires a path');
+      if (!this.routeMap[path]) {
+        throw new Error('path does not exist: ' + path);
+      }
+
+      // find route for this specific path, not necessarily the first that
+      // matches the pattern
+      var match;
+      this.routes.forEach(function eachRoute(route) {
+        if (route.src === path) {
+          match = route;
+        }
+      });
+
+      if (match) {
+        this.routes.splice(match.idx, 1);
+        delete this.routeMap[path];
+
+        // re-index
+        for (var i = match.idx; i<this.routes.length; i++) {
+          this.routes[i].idx = i;
+        }
+        return match;
+      }
+      throw new Error('could not remove route for path: ' + path);
     },
 
     match: function(pathname, startAt){

--- a/test/test.js
+++ b/test/test.js
@@ -256,4 +256,18 @@ var next = match.next();
 strictEqual(next.route, "/next/x");
 assertCount++;
 
+// test remove
+equal(router.routes.length, 14);
+equal(Object.keys(router.routeMap).length, 14);
+router.removeRoute('/next/x');
+equal(router.routes.length, 13);
+equal(Object.keys(router.routeMap).length, 13);
+assertCount++;
+match = router.match('/next/x');
+// next still available, just returns undefined
+equal(typeof match.next, "function");
+next = match.next();
+strictEqual(next, undefined);
+assertCount++
+
 console.log(assertCount.toString()+ " assertions made succesfully");


### PR DESCRIPTION
We have a very unique use-case where for certain environments, routes need to be removed after they have been added. This diff adds the `removeRoute` method.